### PR TITLE
Remove Milos Kleint from users list

### DIFF
--- a/src/main/resources/jira-to-github-users.properties
+++ b/src/main/resources/jira-to-github-users.properties
@@ -78,7 +78,7 @@ mhinterseher:mhinterseher
 michaelo:michael-o
 michael-o:michael-o
 mihobson:markhobson
-mkleint:mkleint
+# mkleint:mkleint # not in ASF
 markh:markhobson
 mfriedenhagen:mfriedenhagen
 #mouyang


### PR DESCRIPTION
An issue of MEAR could not imported and he is no member of the ASF organization on Github (anymore)